### PR TITLE
Fixed: Segmentation Fault for AVX{2,512} 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,5 +61,5 @@ target_link_libraries(vargas hts)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -pedantic -Wall -Wextra -Wno-unused-function")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -pedantic -Wall -Wextra -Wno-unused-function -fno-inline")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_DEBUG}")

--- a/include/align_main.h
+++ b/include/align_main.h
@@ -68,7 +68,7 @@ int align_main(int argc, char *argv[]);
 void align(vargas::GraphMan &gm,
            std::vector<std::pair<std::string, std::vector<vargas::SAM::Record>>> &task_list,
            vargas::osam &out,
-           const std::vector<std::unique_ptr<vargas::AlignerBase>> &aligners,
+           const std::vector<std::unique_ptr<vargas::AlignerBase, rg::Deleter>> &aligners,
            bool fwdonly, bool msonly, bool maxonly, bool notraceback, char phred_offset);
 
 /**
@@ -93,7 +93,7 @@ create_tasks(vargas::isam &reads, std::string &align_targets, int chunk_size, si
  * @param end_to_end End to end alignment
  * @return pointer to new aligner
  */
-std::unique_ptr<vargas::AlignerBase>
+std::unique_ptr<vargas::AlignerBase, rg::Deleter>
 make_aligner(const vargas::ScoreProfile &prof, size_t read_len, bool use_wide, bool msonly, bool maxonly);
 
 /**

--- a/include/alignment.h
+++ b/include/alignment.h
@@ -357,7 +357,7 @@ namespace vargas {
       };
 
 
-      void set_scores(const ScoreProfile &prof) override {
+      virtual void set_scores(const ScoreProfile &prof) override {
           _prof = prof;
           _prof.end_to_end = END_TO_END;
           _bias = _get_bias(_read_len, prof.match, prof.mismatch_max, prof.read_gopen, prof.read_gext);

--- a/include/alignment.h
+++ b/include/alignment.h
@@ -632,6 +632,8 @@ namespace vargas {
       __RG_STRONG_INLINE__
       void _fill_cell(const typename qp_t::value_type &prof, const rg::Base &ref,
                       const unsigned &row, const pos_t &curr_pos) {
+          assert(uint64_t(&_Dc[0]) % sizeof(_Dc[0]) == 0);
+          assert(uint64_t(&_S[0]) % sizeof(_S[0]) == 0);
           _Dc[row] = max(_Dc[row - 1] - _gap_extend_vec_ref, _S[row - 1] - _gap_open_extend_vec_ref);
           _Ic[row] = max(_Ic[row] - _gap_extend_vec_rd, _S[row] - _gap_open_extend_vec_rd);
           simd_t sr = _Sd + prof[ref];

--- a/include/simd.h
+++ b/include/simd.h
@@ -406,7 +406,11 @@ namespace vargas {
       return _mm256_xor_si256(v, o.v);
   }
   template<> int8x32 &int8x32::operator=(const int8x32::native_t o) {
-      v = _mm256_set1_epi8(o);
+      //std::cerr << "Setting item to " << static_cast<int32_t>(o) << '\n';
+      std::fill(reinterpret_cast<int8x32::native_t *>(&v), reinterpret_cast<int8x32::native_t *>(&v) + sizeof(v) / sizeof(o),
+                o);
+      //std::cerr << "Set item to " << static_cast<int32_t>(o) << '\n';
+      //v = _mm256_set1_epi8(o);
       return *this;
   }
   template<> int8x32 int8x32::operator+(const int8x32 &o) const {
@@ -464,7 +468,11 @@ namespace vargas {
       return _mm256_xor_si256(v, o.v);
   }
   template<> int16x16 &int16x16::operator=(const int16x16::native_t o) {
-      v = _mm256_set1_epi16(o);
+      //std::cerr << "Setting item to " << static_cast<int32_t>(o) << '\n';
+      std::fill(reinterpret_cast<int8x32::native_t *>(&v), reinterpret_cast<int8x32::native_t *>(&v) + sizeof(v) / sizeof(o),
+                o);
+      //v = _mm256_set1_epi16(o);
+      //std::cerr << "Set item to " << static_cast<int32_t>(o) << '\n';
       return *this;
   }
   template<> int16x16 int16x16::operator+(const int16x16 &o) const {
@@ -512,7 +520,8 @@ namespace vargas {
       return _mm512_xor_si512(v, o.v);
   }
   template<> int8x64 &int8x64::operator=(const int8x64::native_t o) {
-      v = _mm512_set1_epi8(o);
+      std::fill(reinterpret_cast<int8x32::native_t *>(&v), reinterpret_cast<int8x32::native_t *>(&v) + sizeof(v) / sizeof(o),
+                o);
       return *this;
   }
   template<> int8x64 int8x64::operator+(const int8x64 &o) const {
@@ -557,7 +566,8 @@ namespace vargas {
       return _mm512_xor_si512(v, o.v);
   }
   template<> int16x32 &int16x32::operator=(const int16x32::native_t o) {
-      v = _mm512_set1_epi16(o);
+      std::fill(reinterpret_cast<int8x32::native_t *>(&v), reinterpret_cast<int8x32::native_t *>(&v) + sizeof(v) / sizeof(o),
+                o);
       return *this;
   }
   template<> int16x32 int16x32::operator+(const int16x32 &o) const {

--- a/include/threadpool.h
+++ b/include/threadpool.h
@@ -7,6 +7,8 @@ namespace rg {
 struct ForPool {
     void *fp_;
     ForPool(int nthreads): fp_(kt_forpool_init(nthreads)) {}
+    ForPool(const ForPool &) = delete;
+    ForPool(ForPool &&) = delete;
     void forpool(void (*func)(void*,long,int), void *data, long n) {
         kt_forpool(fp_, func, data, n);
     }

--- a/include/utils.h
+++ b/include/utils.h
@@ -494,6 +494,11 @@ print(", ".join(map(str, map(ord, lut))))
   typename _Unique_if<T>::_Known_bound
   make_unique(Args &&...) = delete;
 
+  struct Deleter {
+      void operator()(const void *p) const {
+          ::std::free(const_cast<void *>(p));
+      }
+  };
 
 }
 

--- a/src/align_main.cpp
+++ b/src/align_main.cpp
@@ -674,24 +674,26 @@ create_tasks(vargas::isam &reads, std::string &align_targets, const int chunk_si
 
 std::unique_ptr<vargas::AlignerBase>
 make_aligner(const vargas::ScoreProfile &prof, size_t read_len, bool use_wide, bool msonly, bool maxonly) {
+    std::unique_ptr<vargas::AlignerBase> ret;
     if (msonly) {
         if (prof.end_to_end) {
-            if (use_wide) return rg::make_unique<vargas::MSWordAlignerETE>(read_len, prof);
-            else return rg::make_unique<vargas::MSAlignerETE>(read_len, prof);
+            if(use_wide) ret.reset(new vargas::MSWordAlignerETE(read_len, prof));
+            else ret.reset(new vargas::MSAlignerETE(read_len, prof));
         } else {
-            if (use_wide) return rg::make_unique<vargas::MSWordAligner>(read_len, prof);
-            else return rg::make_unique<vargas::MSAligner>(read_len, prof);
+            if(use_wide) ret.reset(new vargas::MSWordAligner(read_len, prof));
+            else ret.reset(new vargas::MSAligner(read_len, prof));
         }
     }
     else {
         if (prof.end_to_end) {
-            if (use_wide) return rg::make_unique<vargas::WordAlignerETE>(read_len, prof);
-            else return rg::make_unique<vargas::AlignerETE>(read_len, prof);
+            if(use_wide) ret.reset(new vargas::WordAlignerETE(read_len, prof));
+            else ret.reset(new vargas::AlignerETE(read_len, prof));
         } else {
-            if (use_wide) return rg::make_unique<vargas::WordAligner>(read_len, prof);
-            else return rg::make_unique<vargas::Aligner>(read_len, prof);
+            if(use_wide) ret.reset(new vargas::WordAligner(read_len, prof));
+            else ret.reset(new vargas::Aligner(read_len, prof));
         }
     }
+    return ret;
 }
 
 void load_fast(std::string &file, const bool fastq, vargas::isam &ret, bool p64) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,7 @@ struct main_helper {
     std::mutex &m;
     vargas::osam &out;
 };
-void main_helper_func(void *data, long index, int tid) {
+void main_helper_func(void *data, long index, int) {
     main_helper &help = *(main_helper *)data;
     auto &task_list = help.task_list;
     auto &gm = help.gm;


### PR DESCRIPTION
new and malloc calls default to memory alignment of 128 bits in the current C standard. Because of this, the allocation of the AlignerT needs itself to be aligned with vector width, which was leading to segmentation faults because of unaligned memory.

This patch uses an allocation aligned to 64 bytes for the aligners and uses a custom Deleter class to call std::free during their destructors, which seems to eliminate the bug.