### PR TITLE
vargas as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,7 @@ target_link_libraries(vargas hts)
 target_link_libraries(ibvargas hts)
 target_link_libraries(static-vargas hts)
 
-IF(CMAKE_BUILD_TYPE MATCHES RELEASE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDOCTEST_CONFIG_DISABLE")
-ENDIF(CMAKE_BUILD_TYPE MATCHES RELEASE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDOCTEST_CONFIG_DISABLE")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
 
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDOCTEST_CONFIG_DISABLE")
+endif()
+
 include_directories(doctest/doctest include htslib cxxopts/src)
 link_directories(${PROJECT_SOURCE_DIR}/htslib)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -79,8 +83,6 @@ add_library(static-vargas STATIC ${LIB_SOURCES})
 target_link_libraries(vargas hts)
 target_link_libraries(ibvargas hts)
 target_link_libraries(static-vargas hts)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDOCTEST_CONFIG_DISABLE")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,15 @@ project("vargas")
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
+if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+endif()
+
 include_directories(doctest/doctest include htslib cxxopts/src)
 link_directories(${PROJECT_SOURCE_DIR}/htslib)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(CMAKE_MACOSX_RPATH 1)
+endif()
 
 set(MAIN_SOURCES
         src/main.cpp
@@ -17,6 +24,16 @@ set(MAIN_SOURCES
         src/fasta.cpp
         src/sam.cpp
         src/align_main.cpp
+        src/scoring.cpp
+        src/graphman.cpp)
+
+set(LIB_SOURCES
+        src/graph.cpp
+        src/utils.cpp
+        src/varfile.cpp
+        src/sim.cpp
+        src/fasta.cpp
+        src/sam.cpp
         src/scoring.cpp
         src/graphman.cpp)
 
@@ -57,7 +74,15 @@ else()
 endif()
 
 add_executable(vargas ${MAIN_SOURCES})
+add_library(ibvargas SHARED ${LIB_SOURCES})
+add_library(static-vargas STATIC ${LIB_SOURCES})
 target_link_libraries(vargas hts)
+target_link_libraries(ibvargas hts)
+target_link_libraries(static-vargas hts)
+
+IF(CMAKE_BUILD_TYPE MATCHES RELEASE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDOCTEST_CONFIG_DISABLE")
+ENDIF(CMAKE_BUILD_TYPE MATCHES RELEASE)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,9 @@
  * @file
  */
 
+#ifndef DOCTEST_CONFIG_DISABLE
 #define DOCTEST_CONFIG_IMPLEMENT // User controlled test execution
+#endif
 
 
 #include "main.h"
@@ -31,13 +33,16 @@ int main(int argc, char *argv[]) {
 
     try {
         if (argc > 1) {
+#ifndef DOCTEST_CONFIG_DISABLE
             if (!strcmp(argv[1], "test")) {
                 doctest::Context doc(argc, argv);
                 doc.setOption("abort-after", 5);
                 doc.setOption("no-version", true);
                 std::cerr << "Running tests...\n\n";
                 return doc.run();
-            } else if (!strcmp(argv[1], "profile")) {
+            } else
+#endif
+            if (!strcmp(argv[1], "profile")) {
                 return profile(argc - 1, argv + 1);
             } else if (!strcmp(argv[1], "define")) {
                 return define_main(argc - 1, argv + 1);


### PR DESCRIPTION
Adds targets for static and dynamic library generation (libibvargas.so for shared, and static-vargas.a for static), which would make it easy to use vargas in other software.

This pull request makes a couple of minor changes as well.

1. Doctest tests are disabled for Release builds.
2. Build type defaults to Release.
3. Sets CMAKE_MACOSX_RPATH 1 for Darwin to ensure proper library linkage on OSX.